### PR TITLE
Fix: updated EXPOSE port from 5000 to 5001 to match server port

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,6 +7,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 5000
+EXPOSE 5001
 
 CMD ["npm", "start"]


### PR DESCRIPTION
The server listens on port 5001 but the Dockerfile exposed 5000.
This PR updates EXPOSE to match the actual application port.